### PR TITLE
Sending in options for better console printing to jest-diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 coverage/
 *.log
 .DS_Store
+.vscode

--- a/src/util/compare-translations-structure.js
+++ b/src/util/compare-translations-structure.js
@@ -1,6 +1,10 @@
 const set = require('lodash.set');
 const diff = require('jest-diff');
 const deepForOwn = require('./deep-for-own');
+const DIFF_OPTIONS = {
+  expand: false,
+  contextLines: 1
+};
 
 // we don't care what the actual values are.
 // lodash.set will automatically convert a previous string value
@@ -9,17 +13,13 @@ const deepForOwn = require('./deep-for-own');
 const compareTranslationsStructure = (translationsA, translationsB) => {
   const augmentedTranslationsA = {};
   const augmentedTranslationsB = {};
-  const options = {
-    expand: false,
-    contextLines: 1
-  };
   deepForOwn(translationsA, (value, key, path) => {
     set(augmentedTranslationsA, path, 'Message<String>');
   });
   deepForOwn(translationsB, (value, key, path) => {
     set(augmentedTranslationsB, path, 'Message<String>');
   });
-  return diff(augmentedTranslationsA, augmentedTranslationsB, options);
+  return diff(augmentedTranslationsA, augmentedTranslationsB, DIFF_OPTIONS);
 };
 
 module.exports = compareTranslationsStructure;

--- a/src/util/compare-translations-structure.js
+++ b/src/util/compare-translations-structure.js
@@ -1,6 +1,6 @@
-const set = require("lodash.set");
-const diff = require("jest-diff");
-const deepForOwn = require("./deep-for-own");
+const set = require('lodash.set');
+const diff = require('jest-diff');
+const deepForOwn = require('./deep-for-own');
 
 // we don't care what the actual values are.
 // lodash.set will automatically convert a previous string value
@@ -14,10 +14,10 @@ const compareTranslationsStructure = (translationsA, translationsB) => {
     contextLines: 1
   };
   deepForOwn(translationsA, (value, key, path) => {
-    set(augmentedTranslationsA, path, "Message<String>");
+    set(augmentedTranslationsA, path, 'Message<String>');
   });
   deepForOwn(translationsB, (value, key, path) => {
-    set(augmentedTranslationsB, path, "Message<String>");
+    set(augmentedTranslationsB, path, 'Message<String>');
   });
   return diff(augmentedTranslationsA, augmentedTranslationsB, options);
 };

--- a/src/util/compare-translations-structure.js
+++ b/src/util/compare-translations-structure.js
@@ -1,6 +1,6 @@
-const set = require('lodash.set');
-const diff = require('jest-diff');
-const deepForOwn = require('./deep-for-own');
+const set = require("lodash.set");
+const diff = require("jest-diff");
+const deepForOwn = require("./deep-for-own");
 
 // we don't care what the actual values are.
 // lodash.set will automatically convert a previous string value
@@ -9,13 +9,17 @@ const deepForOwn = require('./deep-for-own');
 const compareTranslationsStructure = (translationsA, translationsB) => {
   const augmentedTranslationsA = {};
   const augmentedTranslationsB = {};
+  const options = {
+    expand: false,
+    contextLines: 1
+  };
   deepForOwn(translationsA, (value, key, path) => {
-    set(augmentedTranslationsA, path, 'Message<String>');
+    set(augmentedTranslationsA, path, "Message<String>");
   });
   deepForOwn(translationsB, (value, key, path) => {
-    set(augmentedTranslationsB, path, 'Message<String>');
+    set(augmentedTranslationsB, path, "Message<String>");
   });
-  return diff(augmentedTranslationsA, augmentedTranslationsB);
+  return diff(augmentedTranslationsA, augmentedTranslationsB, options);
 };
 
 module.exports = compareTranslationsStructure;


### PR DESCRIPTION
Right now it prints every line of each translation file when using the identical-keys rule. That does not work very well for projects with many and large translation files. This pull request sends in options to jest-diff to only print the actual diffs and line numbers to the console, which will give a more expected result in my opinion.