### PR TITLE
Add message for eslint feedback

### DIFF
--- a/src/sort-translations.js
+++ b/src/sort-translations.js
@@ -34,6 +34,7 @@ const sortTranslations = (source) => {
 
   if (!equal(originalTranslationPaths, sortedTranslationPaths)) {
     return [{
+      message: 'Keys should be sorted, please use --fix',
       fix: {
         range: [0, source.length],
         text: JSON.stringify(sortedTranslations, null, 2),

--- a/src/sort-translations.test.js
+++ b/src/sort-translations.test.js
@@ -32,6 +32,7 @@ describe('sortTranslations', () => {
       },
       line: 0,
       column: 0,
+      "message": "Keys should be sorted, please use --fix",
     }]);
   });
   it('will sort nested translations if not already sorted in ASC order', () => {
@@ -66,6 +67,7 @@ describe('sortTranslations', () => {
       },
       line: 0,
       column: 0,
+      "message": "Keys should be sorted, please use --fix",
     }]);
   });
   it('does not fail with other data types in the object', () => {
@@ -100,6 +102,7 @@ describe('sortTranslations', () => {
       },
       line: 0,
       column: 0,
+      "message": "Keys should be sorted, please use --fix",
     }]);
   });
 });


### PR DESCRIPTION
Today, if a json file is not rightly sorted, and we're not using --fix, eslint will fail with this message : 
```
   Expected `input` to be a `string`, got `undefined`
   TypeError: Expected `input` to be a `string`, got `undefined`
```

How to reproduce : use example/simple, change the sort of 2 lines, remove the --fix in script, and `npm run lint`