### PR TITLE
Fixing SecurityError during jest run

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "collectCoverageFrom": [
       "src/**/*.js",
       "formatter.js"
-    ]
+    ],
+    "testEnvironment": "node"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Sometime yesterday a new version of jsdom began throwing an error below when running tests with jest, more info here: https://github.com/facebook/jest/issues/6766

This workaround seems more appropriate for the project than the testURL option mentioned at that link.

```
 FAIL  src/valid-json.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)
```

If it's fixed quickly by jsdom or jest teams, disregard ⏳ 