### PR TITLE
Force loading files from disk

### DIFF
--- a/src/identical-keys.js
+++ b/src/identical-keys.js
@@ -11,7 +11,13 @@ const getKeyStructureFromMap = (filePathMap, sourceFilePath) => {
     .filter(filePath => sourceFilePath.endsWith(filePath)).pop();
   if (match) {
     try {
-      return require(filePathMap[match]);
+      const filepath = filePathMap[match];
+
+      // Delete the file from the require cache.
+      // This forces the file to be read from disk again.
+      delete require.cache[filepath];
+
+      return require(filepath);
     } catch (e) {
       throw new Error(`\n Error parsing or retrieving key structure comparison file based on "filePath" mapping\n\n "${match}" => "${filePathMap[match]}".\n\n Check the "filePath" option for this rule. \n ${e}`);
     }


### PR DESCRIPTION
By default Node will cache modules that have been required in [require.cache](https://nodejs.org/api/modules.html#modules_require_cache).  This change deletes the entry from the cache which forces the file to be reloaded from disk.

This solves issues when running Eslint in webpack-dev-server where an i18n file has been modified and the changes are not picked up because the original file was already read into the cache.

This should have no impact when running Eslint from the CLI.

This solves #20.