### PR TITLE
Fix 'valid-message-syntax' rule with `icu` syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "chalk": "^2.3.2",
     "indent-string": "^3.2.0",
-    "intl-messageformat-parser": "^1.4.0",
+    "intl-messageformat-parser": "^3.0.7",
     "jest-diff": "^22.0.3",
     "jsonlint": "^1.6.2",
     "lodash.get": "^4.4.2",

--- a/src/__snapshots__/valid-message-syntax.test.js.snap
+++ b/src/__snapshots__/valid-message-syntax.test.js.snap
@@ -22,10 +22,12 @@ exports[`Snapshot Tests for Invalid Code nested translations - icu syntax check 
     \\"levelOne\\": Object {
       \\"levelTwo\\": Object {
 -       \\"translationKeyC\\": \\"ValidMessage<String>\\",
-+       \\"translationKeyC\\": \\"String('translation value c {') ===> Expected '0', [1-9] or [^ tnr,.+={}#] but end of input found.\\",
++       \\"translationKeyC\\": \\"String('translation value c {') ===> Expected argNameOrNumber but end of input found.\\",
       },
 -     \\"translationKeyB\\": \\"ValidMessage<String>\\",
-+     \\"translationKeyB\\": \\"String('translation value b {') ===> Expected '0', [1-9] or [^ tnr,.+={}#] but end of input found.\\",
+-     \\"translationKeyD\\": \\"ValidMessage<String>\\",
++     \\"translationKeyB\\": \\"String('translation value b {') ===> Expected argNameOrNumber but end of input found.\\",
++     \\"translationKeyD\\": \\"String('translation value d '{}') ===> Expected ''', '''', or [^'] but end of input found.\\",
     },
   }"
 `;

--- a/src/valid-message-syntax.test.js
+++ b/src/valid-message-syntax.test.js
@@ -22,7 +22,9 @@ ruleTester.run('valid-message-syntax', rule, {
       code: `
       /*{
           "translationKeyA": "translation value a",
-          "translationKeyB": "translation value b"
+          "translationKeyB": "translation value b",
+          "translationKeyC": "translation value escaped curly brackets '{}'",
+          "translationKeyD": "translation value with backslash \u005C"
       }*/
       `,
       options: [
@@ -209,6 +211,7 @@ describe('Snapshot Tests for Invalid Code', () => {
         "levelOne": {
           "translationKeyA": "translation value a",
           "translationKeyB": "translation value b {",
+          "translationKeyD": "translation value d '{}",
           "levelTwo" : {
             "translationKeyC": "translation value c {"
           }


### PR DESCRIPTION
See issue https://github.com/godaddy/eslint-plugin-i18n-json/issues/24 

@mayank23 can you please review?