### PR TITLE
Bug fix: spaced comments lint error

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ module.exports = {
         // augment the json into a comment
         // along with the source path :D
         // so we can pass it to the rules
-        [`/*${source.trim()}*//*${filePath.trim()}*/\n`],
+        
+        // note: due to the spaced comment rule, include 
+        // spaces b/w comments
+        [`/* ${source.trim()} *//* ${filePath.trim()} */\n`],
       // since we only return one line in the preprocess step,
       // we only care about the first array of errors
       postprocess: ([errors]) => [...errors],

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = {
         // augment the json into a comment
         // along with the source path :D
         // so we can pass it to the rules
-        
-        // note: due to the spaced comment rule, include 
+
+        // note: due to the spaced comment rule, include
         // spaces b/w comments
         [`/* ${source.trim()} *//* ${filePath.trim()} */\n`],
       // since we only return one line in the preprocess step,

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
         // so we can pass it to the rules
 
         // note: due to the spaced comment rule, include
-        // spaces b/w comments
+        // spaced comments
         [`/* ${source.trim()} *//* ${filePath.trim()} */\n`],
       // since we only return one line in the preprocess step,
       // we only care about the first array of errors

--- a/src/util/get-translation-file-source.js
+++ b/src/util/get-translation-file-source.js
@@ -25,7 +25,7 @@ module.exports = ({ context, node }) => {
   // valid source
   return {
     valid: true,
-    source,
-    sourceFilePath
+    source: source && source.trim(),
+    sourceFilePath: sourceFilePath && sourceFilePath.trim()
   };
 };

--- a/src/util/get-translation-file-source.test.js
+++ b/src/util/get-translation-file-source.test.js
@@ -34,17 +34,17 @@ describe('#getTranslationFileSource', () => {
     };
     expect(getTranslationFileSource({ context, node })).toEqual(INVALID_FILE_SOURCE);
   });
-  it('will return a valid file source if the source is a json file and it was processed by plugin preprocessor', () => {
+  it('will return a valid trimmed file source if the source is a json file and it was processed by plugin preprocessor', () => {
     const context = {
       getFilename: jest.fn().mockReturnValueOnce('file.json')
     };
     const node = {
       comments: [
         {
-          value: 'json source'
+          value: ' json source '
         },
         {
-          value: 'path/to/file.json'
+          value: ' path/to/file.json '
         }
       ]
     };


### PR DESCRIPTION
Fixes: https://github.com/godaddy/eslint-plugin-i18n-json/issues/28

v2.4.3 updated the pre-processor to remove spaces at the start and end of the comments which wraps the JSON source and file path . However, this triggers the `spaced-comment`. Reverted that previous change to fix. 