### PR TITLE
Add option to check for duplicate values to `identical-keys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Check out the [Examples](examples/) folder to see different use cases.
       };
       ```
 
+  - `checkDuplicateValues`: Boolean (Optional). Default value: `false`. If true, the values will also be checked for duplicates, in comparison to the file specified in `filePath`.
+
   Output from the slightly advanced [identical keys](/examples/multiple-keys-per-locale) example where some keys from the reference translation file (`en-US`) were not found during comparison.
 
   ![](assets/identical-keys-error-screenshot-2018-04-30.png)

--- a/src/__snapshots__/identical-keys.test.js.snap
+++ b/src/__snapshots__/identical-keys.test.js.snap
@@ -20,6 +20,24 @@ exports[`Snapshot Tests for Invalid Code map of comparison files - structure mis
   }"
 `;
 
+exports[`Snapshot Tests for Invalid Code single comparison file - duplicate values 1`] = `
+"
+- Expected
++ Received
+
+@@ -2,7 +2,7 @@
+    \\"translationLevelOne\\": Object {
+-     \\"translationKeyA\\": \\"Message<String>\\",
++     \\"translationKeyA\\": \\"value a\\",
+      \\"translationLevelTwo\\": Object {
+-       \\"translationKeyB\\": \\"Message<String>\\",
++       \\"translationKeyB\\": \\"value b\\",
+        \\"translationsLevelThree\\": Object {
+-         \\"translationKeyC\\": \\"Message<String>\\",
++         \\"translationKeyC\\": \\"value c\\",
+        },"
+`;
+
 exports[`Snapshot Tests for Invalid Code single comparison file - structure mismatch 1`] = `
 "
 - Expected

--- a/src/identical-keys.js
+++ b/src/identical-keys.js
@@ -165,11 +165,12 @@ const identicalKeys = (context, source, sourceFilePath) => {
   }
 
   const { checkDuplicateValues = false } = comparisonOptions;
+  const isSourceFile = sourceFilePath === comparisonOptions.filePath;
   const diffString = compareTranslationsStructure(
     settings,
     keyStructure,
     currentTranslations,
-    checkDuplicateValues
+    checkDuplicateValues && !isSourceFile
   );
 
   if (noDifferenceRegex.test(diffString.trim())) {

--- a/src/identical-keys.js
+++ b/src/identical-keys.js
@@ -34,6 +34,11 @@ const getKeyStructureFromMap = (filePathMap, sourceFilePath) => {
 
     If it's an object , then it should have a mapping b/w file names
     and what key structure file to require.
+
+    checkDuplicateValues = boolean
+
+    If true, the values will also be checked for duplicates,
+    in comparison to the file specified in filePath.
   }
 */
 
@@ -159,10 +164,12 @@ const identicalKeys = (context, source, sourceFilePath) => {
     return errors;
   }
 
+  const { checkDuplicateValues = false } = comparisonOptions;
   const diffString = compareTranslationsStructure(
     settings,
     keyStructure,
-    currentTranslations
+    currentTranslations,
+    checkDuplicateValues
   );
 
   if (noDifferenceRegex.test(diffString.trim())) {
@@ -196,6 +203,9 @@ module.exports = {
         properties: {
           filePath: {
             type: ['string', 'object']
+          },
+          checkDuplicateValues: {
+            type: 'boolean'
           }
         },
         type: 'object'

--- a/src/identical-keys.test.js
+++ b/src/identical-keys.test.js
@@ -94,6 +94,29 @@ ruleTester.run('identical-keys', rule, {
       ],
       filename: 'file.json'
     },
+    // single file path to compare with, while checking for duplicate values
+    {
+      code: `
+      /*{
+        "translationLevelOne": {
+          "translationKeyA": "translated value a",
+          "translationLevelTwo": {
+            "translationKeyB": "translated value b",
+            "translationsLevelThree": {
+              "translationKeyC": "translated value c"
+            }
+          }
+        }
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/compare-file-a.json',
+          checkDuplicateValues: true
+        }
+      ],
+      filename: 'file.json'
+    },
     // mapping to match which file we should use to compare structure
     {
       code: `
@@ -287,6 +310,31 @@ describe('Snapshot Tests for Invalid Code', () => {
       options: [
         {
           filePath: 'path/to/compare-file-a.json'
+        }
+      ],
+      filename: 'file.json'
+    });
+    expect(strip(errors[0].message)).toMatchSnapshot();
+  });
+  test('single comparison file - duplicate values', () => {
+    const errors = run({
+      code: `
+      /*{
+        "translationLevelOne": {
+          "translationKeyA": "value a",
+          "translationLevelTwo": {
+            "translationKeyB": "value b",
+            "translationsLevelThree": {
+              "translationKeyC": "value c"
+            }
+          }
+        }
+      }*//*/path/to/invalid-file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/compare-file-a.json',
+          checkDuplicateValues: true
         }
       ],
       filename: 'file.json'


### PR DESCRIPTION
This is really useful when you have a main file, like `/en/messages.json`, from which all messages are copied to the other files, as it can detect messages that you probably forgot to translate. In cases where the value is expected to be duplicate, one can simply use the setting to ignore keys.

I got an error while running `npm test`, but I also got it when I tested as soon as I cloned the repo, so maybe it's because I'm on Linux?

**Edit:** Nope, looks like that's the same error that the Travis CI build reported.