### PR TITLE
Bump intl-messageformat-parser from v3 to v5 due to CVE-2020-7660

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "chalk": "^2.3.2",
     "indent-string": "^3.2.0",
-    "intl-messageformat-parser": "^3.0.7",
+    "intl-messageformat-parser": "^5.4.0",
     "jest-diff": "^22.0.3",
     "jsonlint": "^1.6.2",
     "lodash.get": "^4.4.2",

--- a/src/__snapshots__/valid-message-syntax.test.js.snap
+++ b/src/__snapshots__/valid-message-syntax.test.js.snap
@@ -25,9 +25,7 @@ exports[`Snapshot Tests for Invalid Code nested translations - icu syntax check 
 +       \\"translationKeyC\\": \\"String('translation value c {') ===> Expected argNameOrNumber but end of input found.\\",
       },
 -     \\"translationKeyB\\": \\"ValidMessage<String>\\",
--     \\"translationKeyD\\": \\"ValidMessage<String>\\",
 +     \\"translationKeyB\\": \\"String('translation value b {') ===> Expected argNameOrNumber but end of input found.\\",
-+     \\"translationKeyD\\": \\"String('translation value d '{}') ===> Expected ''', '''', or [^'] but end of input found.\\",
     },
   }"
 `;


### PR DESCRIPTION
Fix for https://nvd.nist.gov/vuln/detail/CVE-2020-7660. 

```
serialize-javascript version 3.0.0 is listed as a dependency by intl-utils 2.3.0.
intl-utils 2.3.0 is listed as dependency by intl-unified-numberformat 3.3.7
intl-unified-numberformat is listed as a dependency by intl-messageformat-parser 3.6.4
intl-messageformat-parser ^3.0.7 is listed as a dependency in the latest version (2.4.4) of GoDaddy’s NPM package eslint-plugin-i18n-json.
```

Reported By (Thanks!): 
Michael Desantis -  Intertek Alchemy LP