### PR TITLE
Add new rule identical-placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [TBD] - TBD - MAJOR BUMP
+
+- Switch to `@formatjs/icu-messageformat-parser` as `intl-messageformat-parser` is now deprecated. This is a breaking change, the new parser uses icu4j implementation and has stricter validations.
+- Add new rule `i18n-json/identical-placeholders`.
+- Related PRs
+  - TBD
+
+
 ## [3.0.0] - 2020-08-18 - MAJOR BUMP
 
 - **security:** Bump intl-messageformat-parser from v3 to v5 due to [CVE-2020-7660](https://nvd.nist.gov/vuln/detail/CVE-2020-7660)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [TBD] - TBD - MAJOR BUMP
+## [4.0.0] - 2021-04-13 - MAJOR BUMP
 
 - Switch to `@formatjs/icu-messageformat-parser` as `intl-messageformat-parser` is now deprecated. This is a breaking change, the new parser uses icu4j implementation and has stricter validations.
 - Add new rule `i18n-json/identical-placeholders`.
 - Related PRs
-  - TBD
+  - [PR #51](https://github.com/godaddy/eslint-plugin-i18n-json/pull/51)
 
 
 ## [3.0.0] - 2020-08-18 - MAJOR BUMP

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   - [i18n-json/valid-message-syntax](#i18n-jsonvalid-message-syntax)
   - [i18n-json/identical-keys](#i18n-jsonidentical-keys)
   - [i18n-json/sorted-keys](#i18n-jsonsorted-keys)
+  - [i18n-json/identical-placeholders](#i18n-jsonidentical-placeholders)
 - [Settings](#settings)
   - [i18n-json/ignore-keys](#i18n-jsonignore-keys)
 - [Special Thanks](#special-thanks-)
@@ -47,6 +48,9 @@
 - sort translation keys in ascending order through eslint auto-fix (case-sensitive)
   - rule: `i18n-json/sorted-keys`
   - can support a custom sort function to satisfy different sorting needs
+
+- ensure translation files have identical placeholders
+  - rule: `i18n-json/identical-placeholders`
 
 - ability to ignore certain keys. Example: metadata keys, in progress translations, etc.
   - setting: `i18n-json/ignore-keys` [Example](examples/ignore-keys/)
@@ -79,7 +83,7 @@ Right out of the box you get the following through our recommended ruleset `i18n
   - linting of each JSON translation file
   - default severity: error | 2
 - i18n-json/valid-message-syntax
-  - default ICU Message syntax validation (using `intl-messageformat-parser`)
+  - default ICU Message syntax validation (using `@formatjs/icu-messageformat-parser`)
   - default severity: error | 2
 - i18n-json/sorted-keys
   - automatic case-sensitive ascending sort of all keys in the translation file.
@@ -212,7 +216,7 @@ simple
 
 ### i18n-json/valid-message-syntax
 
-- default ICU Message syntax validation (using `intl-messageformat-parser`)
+- default ICU Message syntax validation (using `@formatjs/icu-messageformat-parser`)
 - default severity: error | 2
 - **options**
   - `syntax`: String (Optional). Default value: `icu`.
@@ -360,12 +364,31 @@ simple
 
   ![](assets/fixable-sorting-notice.png)
 
+### i18n-json/identical-placeholders
+
+- compare each translation's placeholders with the refrence file to ensure consistency
+- severity: 0 | off , this rule is OFF by default
+- Can turn this rule on by specifying options for it through your `.eslintrc.*` file.
+- **options**
+  - `filePath` : String (Required)
+
+    - **Can be an absolute path to the reference translation file.**
+      ```javascript
+      // .eslintrc.js
+      module.exports = {
+        rules: {
+          'i18n-json/identical-placeholders': [2, {
+            filePath: path.resolve('path/to/locale/en-US.json'),
+          }],
+        },
+      };
+      ```
 ## Settings
 
 ### i18n-json/ignore-keys
 
 - list of key paths (case sensitive) to ignore when checking syntax and doing key structure comparisons. [Example](examples/ignore-keys/)
-- this setting is used by the following rules: `i18n-json/identical-keys` and `i18n-json/valid-syntax`
+- this setting is used by the following rules: `i18n-json/identical-keys`, `i18n-json/valid-syntax` and `i18n-json/identical-placeholders`.
 - if the key path points to an object, the nested paths are also ignored.
   - e.g. if the key `a` was added to the `ignore-keys` list, then `a.b` will also be ignored.
     ```json
@@ -406,7 +429,7 @@ simple
 
 - Jest platform packages
 
-- intl-messageformat-parser
+- @formatjs/icu-messageformat-parser
 
 - report formatter ui heavily inspired from: https://github.com/sindresorhus/eslint-formatter-pretty
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ simple
 
 ### i18n-json/identical-placeholders
 
-- compare each translation's placeholders with the refrence file to ensure consistency
+- compare each translation's placeholders with the reference file to ensure consistency
 - severity: 0 | off , this rule is OFF by default
 - Can turn this rule on by specifying options for it through your `.eslintrc.*` file.
 - **options**

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports = {
     'valid-json': require('./src/valid-json'),
     'valid-message-syntax': require('./src/valid-message-syntax'),
     'identical-keys': require('./src/identical-keys'),
-    'sorted-keys': require('./src/sorted-keys')
+    'sorted-keys': require('./src/sorted-keys'),
+    'identical-placeholders': require('./src/identical-placeholders')
   },
   processors: {
     '.json': {
@@ -41,7 +42,8 @@ module.exports = {
             indentSpaces: 2
           }
         ],
-        'i18n-json/identical-keys': 0
+        'i18n-json/identical-keys': 0,
+        'i18n-json/identical-placeholders': 0
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-i18n-json",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Fully extendable eslint plugin for JSON i18n translation files.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "strip-ansi": "^4.0.0"
   },
   "dependencies": {
+    "@formatjs/icu-messageformat-parser": "^2.0.18",
     "chalk": "^2.3.2",
     "indent-string": "^3.2.0",
-    "intl-messageformat-parser": "^5.4.0",
     "jest-diff": "^22.0.3",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/src/__snapshots__/valid-message-syntax.test.js.snap
+++ b/src/__snapshots__/valid-message-syntax.test.js.snap
@@ -22,10 +22,10 @@ exports[`Snapshot Tests for Invalid Code nested translations - icu syntax check 
     \\"levelOne\\": Object {
       \\"levelTwo\\": Object {
 -       \\"translationKeyC\\": \\"ValidMessage<String>\\",
-+       \\"translationKeyC\\": \\"String('translation value c {') ===> Expected argNameOrNumber but end of input found.\\",
++       \\"translationKeyC\\": \\"String('translation value c {') ===> EXPECT_ARGUMENT_CLOSING_BRACE\\",
       },
 -     \\"translationKeyB\\": \\"ValidMessage<String>\\",
-+     \\"translationKeyB\\": \\"String('translation value b {') ===> Expected argNameOrNumber but end of input found.\\",
++     \\"translationKeyB\\": \\"String('translation value b {') ===> EXPECT_ARGUMENT_CLOSING_BRACE\\",
     },
   }"
 `;

--- a/src/identical-placeholders.js
+++ b/src/identical-placeholders.js
@@ -1,0 +1,184 @@
+const { parse } = require('@formatjs/icu-messageformat-parser');
+const set = require('lodash.set');
+const get = require('lodash.get');
+const diff = require('jest-diff');
+const requireNoCache = require('./util/require-no-cache');
+const getTranslationFileSource = require('./util/get-translation-file-source');
+const deepForOwn = require('./util/deep-for-own');
+
+const sortAstNodes = (a, b) => `${a.type}${a.value}`.localeCompare(`${b.type}${b.value}`);
+
+const compareAst = (astA, astB) => {
+  // Skip raw text
+  const astAFiltered = astA.filter(a => a.type !== 0).sort(sortAstNodes);
+  const astBFiltered = astB.filter(a => a.type !== 0).sort(sortAstNodes);
+
+  if (astAFiltered.length !== astBFiltered.length) {
+    return false;
+  }
+
+  if (astAFiltered.length === 0) {
+    return true;
+  }
+
+  return astAFiltered.every((elementA, index) => {
+    const elementB = astBFiltered[index];
+
+    // Type and value should match for each placeholder
+    if (elementA.type !== elementB.type || elementA.value !== elementB.value) {
+      return false;
+    }
+
+    // Compare nested elements for type 5 (select) and 6 (plural)
+    if (elementA.type === 5 || elementA.type === 6) {
+      const elementAOptions = Object.keys(elementA.options).sort();
+      const elementBOptions = Object.keys(elementB.options).sort();
+      if (
+        elementAOptions.length !== elementBOptions.length ||
+        elementAOptions.join('|') !== elementBOptions.join('|')
+      ) {
+        return false;
+      }
+
+      return elementAOptions.every(o =>
+        compareAst(elementA.options[o].value, elementB.options[o].value));
+    }
+
+    // Compare children for type 8 (rich text)
+    if (elementA.type === 8) {
+      return compareAst(elementA.children, elementB.children);
+    }
+
+    return true;
+  });
+};
+
+const identicalPlaceholders = (context, source, sourceFilePath) => {
+  const { options, settings } = context;
+  const { filePath } = options[0] || {};
+
+  if (!filePath) {
+    return [
+      {
+        message: '"filePath" rule option not specified.',
+        loc: {
+          start: {
+            line: 0,
+            col: 0
+          }
+        }
+      }
+    ];
+  }
+
+  // skip comparison with reference file
+  if (filePath === sourceFilePath) {
+    return [];
+  }
+
+  let referenceTranslations = null;
+  let sourceTranslations = null;
+  try {
+    referenceTranslations = requireNoCache(filePath);
+    sourceTranslations = JSON.parse(source);
+  } catch (e) {
+    // don't return any errors
+    // will be caught with the valid-json rule.
+    return [];
+  }
+
+  const ignorePaths = settings['i18n-json/ignore-keys'] || [];
+  const invalidMessages = [];
+
+  deepForOwn(
+    referenceTranslations,
+    (referenceTranslation, _, path) => {
+      if (typeof referenceTranslation === 'string') {
+        const sourceTranslation = get(sourceTranslations, path);
+        if (sourceTranslation) {
+          let referenceAst;
+          let sourceAst;
+          try {
+            referenceAst = parse(referenceTranslation);
+            sourceAst = parse(sourceTranslation);
+          } catch (e) {
+            // don't return any errors
+            // will be caught with the valid-message-syntax rule.
+            return;
+          }
+          if (!compareAst(referenceAst, sourceAst)) {
+            invalidMessages.push({
+              path,
+              referenceTranslation,
+              sourceTranslation
+            });
+          }
+        }
+      }
+    },
+    {
+      ignorePaths
+    }
+  );
+
+  if (invalidMessages.length === 0) {
+    return [];
+  }
+
+  const expected = {};
+  const received = {};
+  invalidMessages.forEach(({ path, referenceTranslation, sourceTranslation }) => {
+    set(expected, path, referenceTranslation);
+    set(received, path, `${sourceTranslation} ===> Placeholders don't match`);
+  });
+
+  return [
+    {
+      message: `\n${diff(expected, received)}`,
+      loc: {
+        start: {
+          line: 0,
+          col: 0
+        }
+      }
+    }
+  ];
+};
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Consistency',
+      description:
+        'Verifies the ICU message placeholders for the translations matches with the reference language file specified in the options'
+    },
+    schema: [
+      {
+        properties: {
+          filePath: {
+            type: 'string'
+          }
+        },
+        type: 'object'
+      }
+    ]
+  },
+  create(context) {
+    return {
+      Program(node) {
+        const { valid, source, sourceFilePath } = getTranslationFileSource({
+          context,
+          node
+        });
+        if (!valid) {
+          return;
+        }
+        const errors = identicalPlaceholders(context, source, sourceFilePath);
+        errors.forEach((error) => {
+          context.report(error);
+        });
+      }
+    };
+  }
+};

--- a/src/identical-placeholders.js
+++ b/src/identical-placeholders.js
@@ -10,7 +10,7 @@ const sortAstNodes = (a, b) => `${a.type}${a.value}`.localeCompare(`${b.type}${b
 
 const compareAst = (astA, astB) => {
   // Skip raw text
-  const astAFiltered = astA.filter(a => a.type !== 0).sort(sortAstNodes);
+  const astAFiltered = astA.filter(a => a.type !== TYPE.literal).sort(sortAstNodes);
   const astBFiltered = astB.filter(a => a.type !== 0).sort(sortAstNodes);
 
   if (astAFiltered.length !== astBFiltered.length) {

--- a/src/identical-placeholders.js
+++ b/src/identical-placeholders.js
@@ -44,7 +44,7 @@ const compareAst = (astA, astB) => {
     }
 
     // Compare children for type 8 (rich text)
-    if (elementA.type === 8) {
+    if (elementA.type === TYPE.tag) {
       return compareAst(elementA.children, elementB.children);
     }
 

--- a/src/identical-placeholders.js
+++ b/src/identical-placeholders.js
@@ -11,7 +11,7 @@ const sortAstNodes = (a, b) => `${a.type}${a.value}`.localeCompare(`${b.type}${b
 const compareAst = (astA, astB) => {
   // Skip raw text
   const astAFiltered = astA.filter(a => a.type !== TYPE.literal).sort(sortAstNodes);
-  const astBFiltered = astB.filter(a => a.type !== 0).sort(sortAstNodes);
+  const astBFiltered = astB.filter(a => a.type !== TYPE.literal).sort(sortAstNodes);
 
   if (astAFiltered.length !== astBFiltered.length) {
     return false;

--- a/src/identical-placeholders.js
+++ b/src/identical-placeholders.js
@@ -1,4 +1,4 @@
-const { parse } = require('@formatjs/icu-messageformat-parser');
+const { parse, TYPE } = require('@formatjs/icu-messageformat-parser');
 const set = require('lodash.set');
 const get = require('lodash.get');
 const diff = require('jest-diff');

--- a/src/identical-placeholders.js
+++ b/src/identical-placeholders.js
@@ -29,8 +29,7 @@ const compareAst = (astA, astB) => {
       return false;
     }
 
-    // Compare nested elements for type 5 (select) and 6 (plural)
-    if (elementA.type === 5 || elementA.type === 6) {
+    if (elementA.type === TYPE.select || elementA.type === TYPE.plural) {
       const elementAOptions = Object.keys(elementA.options).sort();
       const elementBOptions = Object.keys(elementB.options).sort();
       if (

--- a/src/identical-placeholders.test.js
+++ b/src/identical-placeholders.test.js
@@ -1,0 +1,295 @@
+const { RuleTester } = require('eslint');
+const rule = require('./identical-placeholders');
+
+const ruleTester = new RuleTester();
+
+jest.mock(
+  'path/to/reference-file.json',
+  () => ({
+    rawText: {
+      label1: 'Title'
+    },
+    noformat: {
+      search: {
+        label2: 'Hi {user}'
+      }
+    },
+    multipleVariables: 'Hi {user}, it is {today, date, medium}.',
+    numberFormat: '{count, number} users',
+    select: 'You selected {choice, select, yes {Yea} no {Nay} other {Maybe}}',
+    'nested.select': '{done, select, no {There is more to it {count, number}.} other {Done.}}',
+    'plural.with.substitution':
+      'Cart: {itemCount, plural, =0 {no items} one {# item} other {# items}}.',
+    richText: 'this is the price <bold>{price, number}</bold>.'
+  }),
+  {
+    virtual: true
+  }
+);
+
+ruleTester.run('identical-placeholders', rule, {
+  valid: [
+    // ignores non json files
+    {
+      code: `
+        /*var x = 123;*//*path/to/file.js*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.js'
+    },
+    // ignores based on ignore-keys settings
+    {
+      code: `
+      /*{
+        "noformat": {
+          "search": {
+            "label2": "Hi {user11}"
+          }
+        }
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      settings: {
+        'i18n-json/ignore-keys': ['noformat.search.label2']
+      }
+    },
+    // ignores invaid format messages
+    {
+      code: `
+      /*{
+        "numberFormat": "{count, number12} users"
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json'
+    },
+    // ignores any differences in raw text
+    {
+      code: `
+      /*{
+        "rawText": {
+          "label1": "†ï†lê"
+        },
+        "plural.with.substitution": '¢คrt -> {itemCount, plural, =0 {ɳσ ιƚҽɱʂ} one {# ιƚҽɱ} other {# ιƚҽɱʂ}}',
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json'
+    },
+    // skips comparison with reference file
+    {
+      code: `
+      /*{
+        "rawText": {
+          "label1": "†ï†lê"
+        }
+      }*//*path/to/reference-file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'reference-file.json'
+    },
+    // doesn't error on valid strings
+    {
+      code: `
+      /*{
+        "rawText": {
+          "label1": "Tιƚʅҽ"
+        },
+        "multipleVariables": "It is {today, date, medium}, {user}.",
+        "numberFormat": "{count, number} users"
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json'
+    }
+  ],
+  invalid: [
+    // errors on invalid config
+    {
+      code: `
+      /*{}*//*path/to/file.json*/
+      `,
+      options: [],
+      filename: 'file.json',
+      errors: [
+        {
+          message: '"filePath" rule option not specified.',
+          line: 0
+        }
+      ]
+    },
+    // errors on variable name mismatch
+    {
+      code: `
+      /*{
+        "noformat": {
+          "search": {
+            "label2": "Hi {user11}"
+          }
+        }
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    },
+    // errors on variables count mismatch
+    {
+      code: `
+      /*{
+        "noformat": {
+          "search": {
+            "label2": "Hi"
+          }
+        }
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    },
+    // errors on 'select' format options mismatch
+    {
+      code: `
+      /*{
+        "select": "You selected {choice, select, YΣƧ {Yea} no {Nay} other {Maybe}}"
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    },
+    // errors on 'select' format options count mismatch
+    {
+      code: `
+      /*{
+        "select": "You selected {choice, select, yes {Yea} other {Maybe}}"
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    },
+    // errors on nested variables mismatch
+    {
+      code: `
+      /*{
+        "nested.select": "{done, select, no {There is more to it {count1, number}.} other {Done.}}"
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    },
+    // errors on 'plural' format options mismatch
+    {
+      code: `
+      /*{
+        "plural.with.substitution": "Cart: {itemCount, plural, =0 {no items} uno {# item} other {# items}}."
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    },
+    // errors on rich text variables mismatch
+    {
+      code: `
+      /*{
+        "richText": "this is the price <bold>{price}</bold>."
+      }*//*path/to/file.json*/
+      `,
+      options: [
+        {
+          filePath: 'path/to/reference-file.json'
+        }
+      ],
+      filename: 'file.json',
+      errors: [
+        {
+          message: /Placeholders don't match/,
+          line: 0
+        }
+      ]
+    }
+  ]
+});

--- a/src/identical-placeholders.test.js
+++ b/src/identical-placeholders.test.js
@@ -27,22 +27,36 @@ jest.mock(
   }
 );
 
+const testCaseConfig = {
+  options: [
+    {
+      filePath: 'path/to/reference-file.json'
+    }
+  ],
+  filename: 'file.json'
+};
+const mismatchError = {
+  errors: [
+    {
+      message: /Placeholders don't match/,
+      line: 0
+    }
+  ]
+};
+
 ruleTester.run('identical-placeholders', rule, {
   valid: [
     // ignores non json files
     {
+      ...testCaseConfig,
       code: `
         /*var x = 123;*//*path/to/file.js*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
       filename: 'file.js'
     },
     // ignores based on ignore-keys settings
     {
+      ...testCaseConfig,
       code: `
       /*{
         "noformat": {
@@ -52,32 +66,22 @@ ruleTester.run('identical-placeholders', rule, {
         }
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
       settings: {
         'i18n-json/ignore-keys': ['noformat.search.label2']
       }
     },
     // ignores invaid format messages
     {
+      ...testCaseConfig,
       code: `
       /*{
         "numberFormat": "{count, number12} users"
       }*//*path/to/file.json*/
-      `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json'
+      `
     },
     // ignores any differences in raw text
     {
+      ...testCaseConfig,
       code: `
       /*{
         "rawText": {
@@ -85,16 +89,11 @@ ruleTester.run('identical-placeholders', rule, {
         },
         "plural.with.substitution": '¢คrt -> {itemCount, plural, =0 {ɳσ ιƚҽɱʂ} one {# ιƚҽɱ} other {# ιƚҽɱʂ}}',
       }*//*path/to/file.json*/
-      `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json'
+      `
     },
     // skips comparison with reference file
     {
+      ...testCaseConfig,
       code: `
       /*{
         "rawText": {
@@ -102,15 +101,11 @@ ruleTester.run('identical-placeholders', rule, {
         }
       }*//*path/to/reference-file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
       filename: 'reference-file.json'
     },
     // doesn't error on valid strings
     {
+      ...testCaseConfig,
       code: `
       /*{
         "rawText": {
@@ -119,23 +114,17 @@ ruleTester.run('identical-placeholders', rule, {
         "multipleVariables": "It is {today, date, medium}, {user}.",
         "numberFormat": "{count, number} users"
       }*//*path/to/file.json*/
-      `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json'
+      `
     }
   ],
   invalid: [
     // errors on invalid config
     {
+      ...testCaseConfig,
       code: `
       /*{}*//*path/to/file.json*/
       `,
       options: [],
-      filename: 'file.json',
       errors: [
         {
           message: '"filePath" rule option not specified.',
@@ -145,6 +134,7 @@ ruleTester.run('identical-placeholders', rule, {
     },
     // errors on variable name mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "noformat": {
@@ -154,21 +144,11 @@ ruleTester.run('identical-placeholders', rule, {
         }
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     },
     // errors on variables count mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "noformat": {
@@ -178,118 +158,57 @@ ruleTester.run('identical-placeholders', rule, {
         }
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     },
     // errors on 'select' format options mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "select": "You selected {choice, select, YΣƧ {Yea} no {Nay} other {Maybe}}"
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     },
     // errors on 'select' format options count mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "select": "You selected {choice, select, yes {Yea} other {Maybe}}"
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     },
     // errors on nested variables mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "nested.select": "{done, select, no {There is more to it {count1, number}.} other {Done.}}"
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     },
     // errors on 'plural' format options mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "plural.with.substitution": "Cart: {itemCount, plural, =0 {no items} uno {# item} other {# items}}."
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     },
     // errors on rich text variables mismatch
     {
+      ...testCaseConfig,
       code: `
       /*{
         "richText": "this is the price <bold>{price}</bold>."
       }*//*path/to/file.json*/
       `,
-      options: [
-        {
-          filePath: 'path/to/reference-file.json'
-        }
-      ],
-      filename: 'file.json',
-      errors: [
-        {
-          message: /Placeholders don't match/,
-          line: 0
-        }
-      ]
+      ...mismatchError
     }
   ]
 });

--- a/src/message-validators/icu.js
+++ b/src/message-validators/icu.js
@@ -1,6 +1,6 @@
-const intlMessageParser = require('intl-messageformat-parser');
+const icuMessageParser = require('@formatjs/icu-messageformat-parser');
 
 // a message validator should throw if there is any error
 module.exports = (message) => {
-  intlMessageParser.parse(message);
+  icuMessageParser.parse(message);
 };


### PR DESCRIPTION
- This PR adds a new rule `i18n-json\identical-placeholders` to help validate the placeholders / variables used in the translations.
- A translator who is not very much familiar with the ICU message syntax, may end up changing (translating) the variables themselves, and breaking the string. Or there may be instances where the string is simply too complex and prone for mistakes.
- This new rule compares any new translations with a reference file ensuring the variables remain the same.