### PR TITLE
fix: allow custom linters to use default exports

### DIFF
--- a/src/valid-json.js
+++ b/src/valid-json.js
@@ -13,7 +13,7 @@ const validJSON = ([{ linter } = {}], source) => {
 
     if (linter) {
       // use custom linter
-      parsed = requireNoCache(linter)(source);
+      parsed = requireNoCache(linter).default ? requireNoCache(linter).default(source) : requireNoCache(linter)(source);
     } else {
       parsed = parseJson(source);
     }


### PR DESCRIPTION
When using modules with a default export this line fails