### PR TITLE
Add Support for arrays

### DIFF
--- a/src/__snapshots__/valid-message-syntax.test.js.snap
+++ b/src/__snapshots__/valid-message-syntax.test.js.snap
@@ -30,19 +30,6 @@ exports[`Snapshot Tests for Invalid Code nested translations - icu syntax check 
   }"
 `;
 
-exports[`Snapshot Tests for Invalid Code no arrays or numbers 1`] = `
-"
-- Expected
-+ Received
-
-  Object {
--   \\"levelOne\\": \\"ObjectContaining<ValidMessages> | ValidMessage<String>\\",
--   \\"levelTwo\\": \\"ValidMessage<String>\\",
-+   \\"levelOne\\": \\"Array [] ===> TypeError: An Array cannot be a translation value.\\",
-+   \\"levelTwo\\": \\"Number(5) ===> Message must be a String.\\",
-  }"
-`;
-
 exports[`Snapshot Tests for Invalid Code no empty objects 1`] = `
 "
 - Expected
@@ -51,6 +38,17 @@ exports[`Snapshot Tests for Invalid Code no empty objects 1`] = `
   Object {
 -   \\"levelOne\\": \\"ObjectContaining<ValidMessages> | ValidMessage<String>\\",
 +   \\"levelOne\\": \\"Object {} ===> SyntaxError: Empty object.\\",
+  }"
+`;
+
+exports[`Snapshot Tests for Invalid Code no numbers 1`] = `
+"
+- Expected
++ Received
+
+  Object {
+-   \\"levelOne\\": \\"ValidMessage<String>\\",
++   \\"levelOne\\": \\"Number(5) ===> Message must be a String.\\",
   }"
 `;
 

--- a/src/valid-message-syntax.js
+++ b/src/valid-message-syntax.js
@@ -11,7 +11,6 @@ const getTranslationFileSource = require('./util/get-translation-file-source');
 
 /* Error tokens */
 const EMPTY_OBJECT = Symbol.for('EMPTY_OBJECT');
-const ARRAY = Symbol.for('ARRAY');
 
 /* Formatting */
 const ALL_BACKSLASHES = /[\\]/g;
@@ -31,7 +30,6 @@ const prettyFormatTypePlugin = {
 const formatExpectedValue = ({ value }) => {
   switch (value) {
     case EMPTY_OBJECT:
-    case ARRAY:
       return 'ObjectContaining<ValidMessages> | ValidMessage<String>';
     default:
       return 'ValidMessage<String>';
@@ -45,8 +43,6 @@ const formatReceivedValue = ({ value, error }) => {
   switch (value) {
     case EMPTY_OBJECT:
       return `${prettyFormat({})} ===> ${error}`;
-    case ARRAY:
-      return `${prettyFormat([])} ===> ${error}`;
     default:
       return `${prettyFormat(value, {
         plugins: [prettyFormatTypePlugin]
@@ -140,13 +136,6 @@ const validMessageSyntax = (context, source) => {
             error: new SyntaxError('Empty object.')
           });
         }
-      } else if (Array.isArray(value)) {
-        invalidMessages.push({
-          value: ARRAY,
-          key,
-          path,
-          error: new TypeError('An Array cannot be a translation value.')
-        });
       } else {
         try {
           validate(value, key);

--- a/src/valid-message-syntax.test.js
+++ b/src/valid-message-syntax.test.js
@@ -261,12 +261,11 @@ describe('Snapshot Tests for Invalid Code', () => {
     });
     expect(strip(errors[0].message)).toMatchSnapshot();
   });
-  test('no arrays or numbers', () => {
+  test('no numbers', () => {
     const errors = run({
       code: `
       /*{
-        "levelOne": [ "data" ],
-        "levelTwo": 5
+        "levelOne": 5
       }*//*path/to/file.json*/
       `,
       options: [


### PR DESCRIPTION
currently `package` is not compatible with `arrays` in json 
it's one of important features for `i18next`

this PR will delete hardcoded validating array and solve [issue-54](https://github.com/godaddy/eslint-plugin-i18n-json/issues/54)