### PR TITLE
feat: support eslint 10

### DIFF
--- a/src/util/get-translation-file-source.js
+++ b/src/util/get-translation-file-source.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const isJSONFile = context => path.extname(context.getFilename()) === '.json';
+const isJSONFile = context => path.extname(context.filename || context.getFilename()) === '.json';
 
 const INVALID_SOURCE = {
   valid: false,


### PR DESCRIPTION
See https://eslint.org/docs/latest/use/migrate-to-10.0.0#-removal-of-deprecated-context-members.

This repo still uses the legacy eslint syntax with .eslintrc, do you want me to upgrade these as well?